### PR TITLE
Add instructions to set up GPG sync in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # FPF GPG Fingerprints
 
-This repository contains an up-to-date list of PGP fingerprints used by Freedom of the Press Foundation.
+This repository contains an up-to-date list of PGP fingerprints used by Freedom of the Press Foundation. The list is signed by the Freedom of the Press Foundation authority key. Here is the authority key:
+
+```
+pub   rsa4096 2018-01-21 [SC] [expires: 2021-01-20]
+      F81962A54902300F72ECB83AA1FC1F6AD2D09049
+uid           [ unknown] FPF Authority (Freedom of the Press Foundation Authority Signing Key)
+```
+
+## Install GPG Sync
+If you're using macOS, fetch the [latest GPG Sync release](https://github.com/firstlookmedia/gpgsync/releases).
+
+If you're a Freedom of the Press Foundation employee and using Linux, `make workstation` should install through the `gpgsync` role.
+
+## Set up GPG Sync
+
+To configure our [GPG Sync](https://github.com/firstlookmedia/gpgsync) endpoint, use these values:
+
+* GPG Fingerprint: `F81962A54902300F72ECB83AA1FC1F6AD2D09049`
+* Fingerprints URL: `https://raw.githubusercontent.com/freedomofpress/fpf-gpg-fingerprints/master/fingerprints.txt`


### PR DESCRIPTION
# Documentation Request
Add instructions to set up GPG sync in README.md, includes installation instructions, information on the FPF authority key, and the values needed to set up the FPF GPG Sync endpoint.

## Testing
I've used these instructions some time ago. Battle tested by one person!